### PR TITLE
Add repository guidance for refactor agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Agent Handbook for `tmux-quick-tabs`
+
+Welcome! This file provides the shared context every agent needs before working in this repository.
+
+## 1. Get Oriented Before You Start
+1. **Read this file in full** to understand repository-wide expectations.
+2. **Open `botfiles/refactor_plan.md`** and locate your step to understand its scope, dependencies, and sequencing. Respect the dependency order—if a prerequisite step is incomplete, complete or coordinate on that first.
+3. **Review your exact instructions in `botfiles/prompts.md`**. Follow the goals, requirements, and deliverables listed for your step.
+4. **Study `botfiles/refactor_requirements.md`**. It documents the canonical behaviour, quirks, and bugs from the existing shell implementation that the Python/libtmux rewrite must replicate.
+5. **Inspect the legacy shell scripts in `scripts/` and `qt-binds.tmux`** when you need behavioural references. They are the ground truth for tmux interactions until your Python replacement is complete.
+
+## 2. General Implementation Guidance
+- Use Python + `libtmux` for new functionality unless your step explicitly keeps shell code.
+- Match the existing user-facing behaviour exactly, including intentional quirks and bugs described in the requirements document.
+- Keep code modular so later steps (dependency checks, bindings, documentation, tests) can integrate cleanly.
+- When introducing new modules, place them under the future `tmux_quick_tabs/` package created in Step 1 and organise related tests under `tests/` (also created in Step 1).
+- Prefer readable, well-documented code (type hints, docstrings where helpful) and reuse shared utilities introduced by earlier steps.
+
+## 3. Quality & Testing Expectations
+- Add or update automated tests as part of your step when feasible. Use `pytest` for Python tests and `shellcheck` for shell scripts once those tools are configured.
+- **Run every test or check you add or modify** before finishing your task. If a check cannot run (e.g., missing tool), document why in your summary.
+- Ensure formatting/linting commands configured in the project (once available) pass before completion.
+
+## 4. Documentation & Configuration
+- Update README or other documentation whenever your changes affect user-visible behaviour or setup instructions.
+- Keep `botfiles/prompts.md` and `botfiles/refactor_plan.md` consistent with the actual project state if you make structural changes that affect future steps.
+- When modifying tmux configuration or shell behaviour, mirror the existing comments and style so users can trace changes easily.
+
+## 5. Communication Back to the Maintainer
+- Summarise what changed and reference the tests you ran in your final response.
+- Highlight any follow-up work needed for later steps (e.g., if you add TODO markers or identify blocked dependencies).
+
+Following these guidelines ensures every agent has the same context and that the refactor proceeds smoothly across all steps.

--- a/botfiles/prompts.md
+++ b/botfiles/prompts.md
@@ -1,0 +1,181 @@
+# Refactor Steps and Agent Prompts
+
+> **Start here:** Before executing any prompt below, read `AGENTS.md` for repository-wide rules, confirm your step and its dependencies in `botfiles/refactor_plan.md`, and review behavioural requirements in `botfiles/refactor_requirements.md`.
+
+## Step 1 — Establish Python project scaffolding
+*Dependencies:* none
+```
+You are working on Step 1 of the tmux-quick-tabs refactor: establish the Python project scaffolding.
+Goals:
+1. Create the initial Python package layout (pyproject.toml, tmux_quick_tabs package, entry module).
+2. Configure linting/formatting hooks and document how to activate the virtual environment.
+Requirements:
+- Follow guidance in botfiles/refactor_requirements.md.
+- Prefer modern Python packaging practices.
+Deliverables:
+- Scaffolding files committed and ready for subsequent steps.
+- Notes on development setup if needed.
+```
+
+## Step 2 — Implement tab-group discovery
+*Dependencies:* Step 1
+```
+You are working on Step 2 of the tmux-quick-tabs refactor: implement tab-group discovery and creation.
+Goals:
+1. Provide a function `get_or_create_tab_group(pane)` returning a detached libtmux Session named `tabs_<session>_<window>_<pane>`.
+2. Mirror tmux display formatting logic to derive the session name.
+Requirements:
+- Create the hidden session if it does not exist.
+- Add unit tests verifying session naming and creation behavior.
+Deliverables:
+- Implementation module.
+- Test coverage for success and existing-session cases.
+```
+
+## Step 3 — Replicate “create new tab” behavior (`C-t` without prefix)
+*Dependencies:* Step 2
+```
+Implement Step 3: the "create new tab" command.
+Goals:
+1. Reproduce scripts/new-tab.sh and create-tab.sh behavior using libtmux.
+2. Swap panes into the hidden session, open the initialization popup, then rotate hidden windows.
+Requirements:
+- Fail if zoxide or fzf are missing (to be relaxed later in Step 8).
+- Include tests mocking libtmux to confirm rotation and popup invocation.
+Deliverables:
+- Command implementation.
+- Unit tests demonstrating expected tmux calls.
+```
+
+## Step 4 — Replicate “cycle to next tab” (`C-n` without prefix)
+*Dependencies:* Step 2
+```
+Implement Step 4: cycle to the next tab.
+Goals:
+1. Swap the active pane with tab_group:1 and rotate hidden windows.
+2. Preserve the original bug where `tmux new` is used instead of `new-session`.
+Requirements:
+- Handle missing hidden session by creating it with the buggy command.
+- Add tests covering present and absent session scenarios.
+Deliverables:
+- Command implementation.
+- Associated unit tests.
+```
+
+## Step 5 — Implement “choose tab” tree (`prefix + C-n`)
+*Dependencies:* Step 2
+```
+Implement Step 5: the "choose tab" tree command.
+Goals:
+1. Use `choose-tree` filtered to panes within the hidden tab session.
+2. Swap the selected pane with the active pane in the visible window.
+Requirements:
+- Match output formatting from scripts/choose-tab.sh.
+- Write tests that simulate choose-tree selection and confirm pane swapping.
+Deliverables:
+- Command implementation.
+- Unit tests for selection handling.
+```
+
+## Step 6 — Implement “close tab” (`prefix + C-t`)
+*Dependencies:* Step 2
+```
+Implement Step 6: the "close tab" command.
+Goals:
+1. Swap the active pane with tab_group:1 and kill that pane.
+2. Keep the hidden session alive even when no panes remain.
+Requirements:
+- Mirror the original script behavior exactly, including window rotation semantics.
+- Provide tests verifying pane kill operations and session persistence.
+Deliverables:
+- Command implementation.
+- Unit tests for closing behavior.
+```
+
+## Step 7 — Implement “new window” popup (`prefix + c`)
+*Dependencies:* Step 1
+```
+Implement Step 7: new-window popup.
+Goals:
+1. Prompt the user for a window name and run `tmux neww -n <name>`.
+2. Send the initialization command from the shell script version without validation.
+Requirements:
+- Allow empty names to mirror existing failure modes.
+- Write tests mocking user input and tmux command execution.
+Deliverables:
+- Command implementation.
+- Associated unit tests.
+```
+
+## Step 8 — Centralize dependency checks
+*Dependencies:* Step 3, Step 4, Step 5, Step 6, Step 7
+```
+Implement Step 8: centralized dependency checks.
+Goals:
+1. Provide a reusable check for zoxide and fzf availability.
+2. Emit warnings instead of hard failures while preserving prior behaviors when dependencies are missing.
+Requirements:
+- Integrate checks into commands from Steps 3–7.
+- Add tests ensuring warnings fire correctly and commands still execute when possible.
+Deliverables:
+- Dependency utility module.
+- Updated commands with coverage for dependency scenarios.
+```
+
+## Step 9 — Bind keys and TPM integration
+*Dependencies:* Step 3, Step 4, Step 5, Step 6, Step 7
+```
+Implement Step 9: key bindings and TPM integration.
+Goals:
+1. Provide a tmux configuration snippet equivalent to qt-binds.tmux using the new Python entrypoints.
+2. Ensure the plugin functions when installed via TPM (`set -g @plugin 'meltingshoe/tmux-quick-tabs'`).
+Requirements:
+- Document required key bindings and configuration variables.
+- Add tests or scripts validating that bindings invoke the correct commands.
+Deliverables:
+- Updated tmux configuration assets.
+- Documentation or tests demonstrating integration.
+```
+
+## Step 10 — Add automated tests and linting
+*Dependencies:* Step 3, Step 4, Step 5, Step 6, Step 7, Step 8, Step 9
+```
+Implement Step 10: automated tests and linting.
+Goals:
+1. Ensure unit tests cover each command’s libtmux interactions and shell fallbacks.
+2. Add tooling such as pytest configuration and shellcheck for remaining scripts.
+Requirements:
+- Update CI or local automation instructions.
+- Provide evidence that tests and linters run successfully.
+Deliverables:
+- Testing and linting configuration files.
+- Documentation updates describing how to run the checks.
+```
+
+## Step 11 — Update documentation
+*Dependencies:* Step 10
+```
+Implement Step 11: documentation refresh.
+Goals:
+1. Revise README to describe the Python implementation, installation, and key bindings.
+2. Document testing instructions, known limitations, and environment expectations.
+Requirements:
+- Reference earlier steps’ outcomes and note preserved quirks.
+- Include migration instructions where appropriate.
+Deliverables:
+- Updated README and any supporting docs.
+```
+
+## Step 12 — Provide migration and maintenance notes
+*Dependencies:* Step 11
+```
+Implement Step 12: migration and maintenance notes.
+Goals:
+1. Explain how to transition from shell scripts to the Python plugin.
+2. Outline ongoing maintenance practices and future improvement ideas.
+Requirements:
+- Highlight common pitfalls encountered during migration.
+- Suggest monitoring or troubleshooting tips for maintainers.
+Deliverables:
+- Migration guide and maintenance notes appended to documentation.
+```

--- a/botfiles/refactor_plan.md
+++ b/botfiles/refactor_plan.md
@@ -1,0 +1,137 @@
+# Refactor Execution Plan
+
+### Step 1 — Establish Python project scaffolding
+*Dependencies:* none  
+Create a new directory structure, `pyproject.toml`, and an entry module (e.g., `tmux_quick_tabs/__init__.py`). Configure linting/formatting hooks and virtual environment.
+
+### Step 2 — Implement tab‑group discovery
+*Dependencies:* Step 1  
+Use `libtmux` to reproduce `tmux display -p "tabs_#S_#W_#P"` and ensure a detached session named `tabs_<session>_<window>_<pane>` exists (creating it if missing).
+
+### Step 3 — Replicate “create new tab” behavior (`C‑t` without prefix)
+*Dependencies:* Step 2  
+Port `scripts/new-tab.sh` and `create-tab.sh` logic: create a new window in the hidden session, swap panes, invoke a popup to run the initialization command (`cd $(zoxide query -l | fzf); clear; ls -a`), then rotate hidden windows.
+
+### Step 4 — Replicate “cycle to next tab” (`C‑n` without prefix)
+*Dependencies:* Step 2  
+Port `scripts/next-tab.sh`: swap the active pane with `tab_group:1`, rotate windows, and mirror the original bug where `tmux new` is used instead of `new-session`.
+
+### Step 5 — Implement “choose tab” tree (`prefix + C‑n`)
+*Dependencies:* Step 2  
+Port `scripts/choose-tab.sh`: generate the pane list via `choose-tree` filtered by hidden session panes, and swap the chosen pane with the active one.
+
+### Step 6 — Implement “close tab” (`prefix + C‑t`)
+*Dependencies:* Step 2  
+Port `scripts/close-tab.sh`: swap with `tab_group:1`, kill that pane, and intentionally keep the hidden session alive even when empty.
+
+### Step 7 — Implement “new window” popup (`prefix + c`)
+*Dependencies:* Step 1  
+Port `scripts/new-window.sh`: prompt for a name, run `tmux neww -n <name>`, and send the `zoxide`/`fzf` initialization command without validation.
+
+### Step 8 — Centralize dependency checks
+*Dependencies:* Step 3, Step 4, Step 5, Step 6, Step 7  
+Verify presence of `zoxide` and `fzf`; emit warnings if missing but preserve existing behavior otherwise.
+
+### Step 9 — Bind keys and TPM integration
+*Dependencies:* Step 3, Step 4, Step 5, Step 6, Step 7  
+Provide a `.tmux` configuration snippet mimicking `qt-binds.tmux`; ensure plugin works when added via `set -g @plugin 'meltingshoe/tmux-quick-tabs'`.
+
+### Step 10 — Add automated tests and linting
+*Dependencies:* Step 3, Step 4, Step 5, Step 6, Step 7, Step 8, Step 9  
+Unit-test each command’s `libtmux` interactions and shell fallbacks; add `shellcheck` for remaining scripts.
+
+### Step 11 — Update documentation
+*Dependencies:* Step 10  
+Revise README to describe Python version, exact behavior, TPM installation, known limitations, and testing instructions.
+
+### Step 12 — Provide migration and maintenance notes
+*Dependencies:* Step 11  
+Explain how to transition from shell scripts to Python plugin, outline common pitfalls, and document future improvement ideas.
+
+---
+
+## Agent Prompts
+
+**Generic structure for each agent**  
+```
+You are working on <Step X> from the tmux-quick-tabs refactor.
+Goals:
+1. <summary of step>
+2. Preserve existing quirks described in botfiles/refactor_requirements.md.
+Requirements:
+- Use Python + libtmux (or shell where specified).
+- Follow repo style and instructions.
+- Output only final files/commands; no extra commentary.
+Deliverables:
+- Code implementing the feature.
+- Updated tests/documentation if relevant.
+```
+
+### Example Prompts
+
+1. **Step 2 Agent (Tab-group discovery)**
+   ```
+   You are working on Step 2 of the tmux-quick-tabs refactor: implement tab-group discovery and creation.
+   - Expose a function `get_or_create_tab_group(pane)` that returns a libtmux Session named `tabs_<session>_<window>_<pane>`.
+   - Must create the session detached if it does not exist.
+   - Add unit tests verifying session naming.
+   ```
+
+2. **Step 3 Agent (Create new tab)**
+   ```
+   Implement Step 3: the "create new tab" command.
+   - Reproduce scripts/new-tab.sh and create-tab.sh behavior.
+   - Swap panes into the hidden session, open a popup to run the init command, then rotate hidden windows.
+   - Fail if zoxide/fzf are missing (dependency check in Step 8 will later relax this).
+   - Include tests that mock libtmux and confirm the rotation.
+   ```
+
+3. **Step 4 Agent (Cycle to next tab)**
+   ```
+   Implement Step 4: cycle to the next tab.
+   - Swap the active pane with tab_group:1 and rotate.
+   - Reproduce the existing bug where 'tmux new' is used instead of 'new-session'.
+   - Provide tests showing behavior when the session is absent.
+   ```
+
+4. **Step 7 Agent (New window popup)**
+   ```
+   Implement Step 7: new-window popup.
+   - Prompt user for a window name; run 'tmux neww -n <name>'.
+   - Send the initialization command and allow empty name (preserving failure behavior).
+   - Write tests mocking user input and command execution.
+   ```
+
+(Continue generating prompts for remaining steps similarly.)
+
+---
+
+## Orchestrating Multiple Agents
+
+### Dependency Graph Highlights
+- **Root:** Step 1 must complete before any other step.
+- **Early Parallelism:**  
+  After Step 2 finishes, Steps 3–6 can run in parallel since they all depend on tab-group logic but not on each other.  
+  Step 7 can begin once Step 1 is done (independent of Step 2).
+- **Integration Phase:**  
+  Step 8 waits for Steps 3–7.  
+  Step 9 depends on Steps 3–7 as well but can run concurrently with Step 8.  
+  Step 10 requires Steps 3–9 to be finished.  
+  Step 11 waits on tests (Step 10), and Step 12 follows documentation updates.
+
+### Suggested Orchestration
+1. **Agent A:** complete Step 1 → spawn Agent B for Step 2 and Agent C for Step 7 simultaneously.
+2. **Agent B:** once Step 2 done, spawn Agents D–G for Steps 3–6 in parallel.
+3. **Agents D–G + C:** once all finish, spawn Agents H (Step 8) and I (Step 9) concurrently.
+4. **Agent J:** after H and I complete, handle Step 10.
+5. **Agent K:** proceed with Step 11.
+6. **Agent L:** finalize with Step 12.
+
+This orchestration allows maximum concurrency while respecting dependencies. A single agent could instead follow the numbered steps sequentially.
+
+---
+
+## Execution Notes
+- Each agent should reference `botfiles/refactor_requirements.md` to match existing behavior.
+- Encourage agents to write unit tests early (within their step) to reduce integration issues later.
+- Use a shared issue tracker or checklist to mark completion and unblock dependent tasks.


### PR DESCRIPTION
## Summary
- add AGENTS.md with repository-wide orientation and expectations for refactor contributors
- remind agents via prompts preamble to consult AGENTS.md, the plan, and requirements before starting a step

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68c8395f847083238c7791e83be5f140