### PR TITLE
Bootstrap Python project scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Python virtual environments
+.venv/
+
+# Byte-compiled / cache files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Tooling caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+
+# IDE settings
+.vscode/
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+minimum_pre_commit_version: "3.5.0"
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.7
+    hooks:
+      - id: ruff
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -24,3 +24,31 @@ Slide-over tab group
   just a floating window
   probably have to attach it to a session tho which will be hard
 tabs are fixed
+
+## Development setup
+
+The Python rewrite lives in the `src/tmux_quick_tabs` package and is distributed via
+`pyproject.toml`.  To work on the refactor you can create an isolated environment and
+install the editable project plus development tools:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e '.[dev]'
+pre-commit install
+```
+
+The `pre-commit` hooks format and lint the codebase with [Ruff](https://github.com/astral-sh/ruff)
+whenever you commit changes.  Run them manually with `pre-commit run --all-files` when needed.
+
+When the virtual environment is active your shell prompt should include `(.venv)`.  Deactivate
+it with `deactivate` once you finish hacking.
+
+You can inspect the placeholder CLI with:
+
+```bash
+python -m tmux_quick_tabs --version
+```
+
+Future steps in the refactor will flesh out the Python package to replace the shell scripts
+shipped with this repository today.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,68 @@
+[build-system]
+requires = ["hatchling>=1.18.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "tmux-quick-tabs"
+version = "0.1.0"
+description = "A Python rewrite of the tmux-quick-tabs plugin."
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [
+  { name = "meltingshoe" },
+]
+dependencies = [
+  "libtmux>=0.28",
+]
+classifiers = [
+  "Development Status :: 2 - Pre-Alpha",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
+keywords = ["tmux", "tabs", "productivity"]
+
+[project.urls]
+Homepage = "https://github.com/meltingshoe/tmux-quick-tabs"
+Repository = "https://github.com/meltingshoe/tmux-quick-tabs"
+
+[project.optional-dependencies]
+dev = [
+  "pre-commit>=3.5",
+  "ruff>=0.4.7",
+]
+
+[project.scripts]
+tmux-quick-tabs = "tmux_quick_tabs.__main__:main"
+
+[tool.hatch.build.targets.wheel]
+packages = [{ include = "tmux_quick_tabs", from = "src" }]
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "src/tmux_quick_tabs",
+  "tests",
+  "README.md",
+  "pyproject.toml",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+ignore = ["E203"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.ruff.lint.isort]
+combine-as-imports = true

--- a/src/tmux_quick_tabs/__init__.py
+++ b/src/tmux_quick_tabs/__init__.py
@@ -1,0 +1,11 @@
+"""tmux-quick-tabs Python package."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+# NOTE: The version is defined here instead of dynamically deriving it so that
+# importing :mod:`tmux_quick_tabs` has no side effects during early
+# bootstrapping of the refactor. Later steps can update this value when the
+# Python implementation becomes feature complete.
+__version__ = "0.1.0"

--- a/src/tmux_quick_tabs/__main__.py
+++ b/src/tmux_quick_tabs/__main__.py
@@ -1,0 +1,38 @@
+"""Command line entry point for tmux-quick-tabs."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+
+from . import __version__
+
+__all__ = ["main"]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the argument parser used by :func:`main`."""
+
+    parser = argparse.ArgumentParser(
+        prog="tmux-quick-tabs",
+        description=(
+            "Bootstrap CLI for the tmux-quick-tabs refactor. Later steps will "
+            "replace this placeholder with real commands that replicate the "
+            "existing shell scripts."
+        ),
+    )
+    parser.add_argument("--version", action="version", version=__version__)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Execute the placeholder CLI."""
+
+    parser = build_parser()
+    parser.parse_args(argv)
+    print("tmux-quick-tabs' Python CLI is under construction.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI execution guard
+    raise SystemExit(main())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+"""Test suite for the tmux-quick-tabs Python implementation."""
+
+from __future__ import annotations
+
+# Test modules will be added once the Python refactor progresses beyond
+# scaffolding. Keeping this package in place helps pytest discover tests in
+# subsequent steps.


### PR DESCRIPTION
## Summary
- add a pyproject.toml using hatchling with a src/ layout and ruff configuration
- scaffold the tmux_quick_tabs package with a placeholder CLI entry point and tests package
- set up pre-commit hooks and document virtualenv activation in the README

## Testing
- `ruff check .`
- `ruff format --check .`


------
https://chatgpt.com/codex/tasks/task_e_68c84abf8c948323ba00d4efbe61b8f4