### PR TITLE
Implement new-window popup command

### DIFF
--- a/src/tmux_quick_tabs/__main__.py
+++ b/src/tmux_quick_tabs/__main__.py
@@ -6,6 +6,7 @@ import argparse
 from collections.abc import Sequence
 
 from . import __version__
+from .new_window import run_new_window
 
 __all__ = ["main"]
 
@@ -22,14 +23,31 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument("--version", action="version", version=__version__)
+    subparsers = parser.add_subparsers(dest="command")
+
+    new_window_parser = subparsers.add_parser(
+        "new-window",
+        help="Open a popup that creates a tmux window using shell-style prompts.",
+    )
+    new_window_parser.set_defaults(func=_run_new_window_command)
     return parser
+
+
+def _run_new_window_command(_args: argparse.Namespace) -> int:
+    """Entrypoint used by the ``new-window`` subcommand."""
+
+    run_new_window()
+    return 0
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Execute the placeholder CLI."""
 
     parser = build_parser()
-    parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    handler = getattr(args, "func", None)
+    if handler is not None:
+        return handler(args)
     print("tmux-quick-tabs' Python CLI is under construction.")
     return 0
 

--- a/src/tmux_quick_tabs/new_window.py
+++ b/src/tmux_quick_tabs/new_window.py
@@ -1,0 +1,70 @@
+"""Implementation of the new-window popup command."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import sys
+from typing import TextIO
+
+from libtmux import Server
+from libtmux.exc import LibTmuxException
+
+__all__ = [
+    "INITIALIZATION_COMMAND",
+    "NewWindowCommand",
+    "run_new_window",
+]
+
+INITIALIZATION_COMMAND = "cd $(zoxide query -l | fzf); clear; ls -a"
+
+
+@dataclass(slots=True)
+class NewWindowCommand:
+    """Handle prompting for a new window name and initialisation."""
+
+    server: Server
+    stdin: TextIO
+    stdout: TextIO
+
+    def prompt(self) -> str:
+        """Prompt the user for the window name."""
+
+        print("Enter window name:", file=self.stdout)
+        self.stdout.flush()
+        line = self.stdin.readline()
+        if line.endswith("\n"):
+            line = line[:-1]
+        return line
+
+    def _split_name(self, name: str) -> list[str]:
+        """Replicate shell word-splitting for the provided *name*."""
+
+        return name.split()
+
+    def run(self) -> None:
+        """Execute the command to create the window and send the init command."""
+
+        name = self.prompt()
+        args = self._split_name(name)
+        try:
+            self.server.cmd("neww", "-n", *args)
+        except LibTmuxException:
+            # Mirrors the shell script behaviour which ignores tmux failures and
+            # proceeds to send the initialisation command regardless.
+            pass
+        self.server.cmd("send-keys", INITIALIZATION_COMMAND, "Enter")
+
+
+def run_new_window(
+    *,
+    server: Server | None = None,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+) -> None:
+    """Run the new-window popup command."""
+
+    server = Server() if server is None else server
+    stdin = sys.stdin if stdin is None else stdin
+    stdout = sys.stdout if stdout is None else stdout
+    command = NewWindowCommand(server=server, stdin=stdin, stdout=stdout)
+    command.run()

--- a/tests/test_new_window.py
+++ b/tests/test_new_window.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import sys
+import types
+from io import StringIO
+from pathlib import Path
+from unittest.mock import Mock
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+try:  # pragma: no cover - fallback for environments without libtmux
+    from libtmux import Server  # type: ignore
+    from libtmux.exc import LibTmuxException
+except ModuleNotFoundError:  # pragma: no cover - executed only in CI where libtmux missing
+    libtmux_module = types.ModuleType("libtmux")
+
+    class Server:  # type: ignore[too-many-ancestors]
+        """Minimal stub used when libtmux is unavailable during tests."""
+
+        def cmd(self, *args: object, **kwargs: object) -> None:  # pragma: no cover - not used
+            raise NotImplementedError
+
+    exc_module = types.ModuleType("libtmux.exc")
+
+    class LibTmuxException(Exception):
+        """Placeholder exception matching the real libtmux hierarchy."""
+
+    exc_module.LibTmuxException = LibTmuxException
+    libtmux_module.Server = Server
+    libtmux_module.exc = exc_module
+    sys.modules["libtmux"] = libtmux_module
+    sys.modules["libtmux.exc"] = exc_module
+
+    from libtmux.exc import LibTmuxException  # type: ignore  # noqa: E402
+
+from tmux_quick_tabs.new_window import INITIALIZATION_COMMAND, run_new_window
+
+
+def make_mock_server():
+    return Mock(spec=["cmd"])
+
+
+def test_run_new_window_with_simple_name():
+    server = make_mock_server()
+    stdin = StringIO("dev\n")
+    stdout = StringIO()
+
+    run_new_window(server=server, stdin=stdin, stdout=stdout)
+
+    server.cmd.assert_any_call("neww", "-n", "dev")
+    server.cmd.assert_any_call("send-keys", INITIALIZATION_COMMAND, "Enter")
+    assert stdout.getvalue() == "Enter window name:\n"
+
+
+def test_run_new_window_with_spaces_in_name():
+    server = make_mock_server()
+    stdin = StringIO("foo bar\n")
+    stdout = StringIO()
+
+    run_new_window(server=server, stdin=stdin, stdout=stdout)
+
+    server.cmd.assert_any_call("neww", "-n", "foo", "bar")
+    server.cmd.assert_any_call("send-keys", INITIALIZATION_COMMAND, "Enter")
+
+
+def test_run_new_window_allows_empty_name_and_still_sends_keys():
+    server = make_mock_server()
+    stdin = StringIO("\n")
+    stdout = StringIO()
+
+    server.cmd.side_effect = [LibTmuxException("usage error"), None]
+
+    run_new_window(server=server, stdin=stdin, stdout=stdout)
+
+    assert server.cmd.call_args_list[0].args == ("neww", "-n")
+    assert server.cmd.call_args_list[1].args == (
+        "send-keys",
+        INITIALIZATION_COMMAND,
+        "Enter",
+    )


### PR DESCRIPTION
## Summary
- add a libtmux-backed implementation of the new-window popup that preserves shell quirks
- expose the new-window behaviour through a CLI subcommand and prompt helper
- cover the new-window command with unit tests that stub libtmux when unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c84cd6af448323a8935d6db1c8e422