### PR TITLE
Implement tab group discovery

### DIFF
--- a/src/tmux_quick_tabs/tab_groups.py
+++ b/src/tmux_quick_tabs/tab_groups.py
@@ -1,0 +1,57 @@
+"""Utilities for discovering and creating hidden tab sessions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from libtmux import Pane, Session
+    from libtmux.server import Server
+
+__all__ = ["TAB_GROUP_FORMAT", "format_tab_group_name", "get_or_create_tab_group"]
+
+# Matches ``tmux display -p "tabs_#S_#W_#P"`` from the shell implementation.
+TAB_GROUP_FORMAT = "tabs_#S_#W_#P"
+
+
+def format_tab_group_name(pane: "Pane") -> str:
+    """Return the hidden session name for *pane*.
+
+    tmux's format expansion rules are mirrored by delegating to
+    :meth:`libtmux.Pane.display_message`, which is the programmatic equivalent of
+    ``tmux display -p``.
+    """
+
+    # ``display_message`` returns either a string or a list of strings depending
+    # on the tmux command invoked. ``get_text=True`` matches the ``-p`` flag
+    # used by the original shell implementation and avoids printing to the
+    # status line.
+    message = pane.display_message(TAB_GROUP_FORMAT, get_text=True)
+    if isinstance(message, list):
+        # When tmux returns a list we only need the first element, which mirrors
+        # how ``tmux display -p`` returns the formatted value.
+        if not message:
+            raise RuntimeError("tmux did not return a tab group name")
+        return message[0]
+    if not isinstance(message, str):
+        raise RuntimeError("Unexpected response from tmux when formatting tab group name")
+    return message
+
+
+def get_or_create_tab_group(pane: "Pane") -> "Session":
+    """Return the detached session used to store hidden tabs for *pane*.
+
+    The session mirrors the ``tabs_<session>_<window>_<pane>`` naming scheme
+    from the original shell scripts. If the session does not exist it is
+    created in a detached state.
+    """
+
+    session_name = format_tab_group_name(pane)
+    server: "Server" = pane.session.server
+
+    existing_session = server.sessions.get(session_name=session_name, default=None)
+    if existing_session is not None:
+        return existing_session
+
+    return server.new_session(session_name=session_name, attach=False)
+

--- a/tests/test_tab_groups.py
+++ b/tests/test_tab_groups.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from tmux_quick_tabs.tab_groups import (  # noqa: E402  - added to sys.path at runtime
+    TAB_GROUP_FORMAT,
+    get_or_create_tab_group,
+)
+
+
+def make_pane(*, session_name: str = "tabs_default"):
+    pane = Mock()
+    server = Mock()
+    sessions = Mock()
+    server.sessions = sessions
+    pane.session = Mock()
+    pane.session.server = server
+    pane.display_message.return_value = session_name
+    return pane, server, sessions
+
+
+def test_get_or_create_tab_group_creates_missing_session():
+    pane, server, sessions = make_pane(session_name="tabs_main_dev_1")
+    created_session = Mock()
+    sessions.get.return_value = None
+    server.new_session.return_value = created_session
+
+    result = get_or_create_tab_group(pane)
+
+    pane.display_message.assert_called_once_with(TAB_GROUP_FORMAT, get_text=True)
+    sessions.get.assert_called_once_with(
+        session_name="tabs_main_dev_1", default=None
+    )
+    server.new_session.assert_called_once_with(
+        session_name="tabs_main_dev_1", attach=False
+    )
+    assert result is created_session
+
+
+def test_get_or_create_tab_group_returns_existing_session():
+    pane, server, sessions = make_pane(session_name="tabs_work_2_0")
+    existing_session = Mock()
+    sessions.get.return_value = existing_session
+
+    result = get_or_create_tab_group(pane)
+
+    server.new_session.assert_not_called()
+    assert result is existing_session
+
+
+def test_get_or_create_tab_group_supports_list_output_from_tmux():
+    pane, server, sessions = make_pane()
+    pane.display_message.return_value = ["tabs_dev_1_3"]
+    existing_session = Mock()
+    sessions.get.return_value = existing_session
+
+    result = get_or_create_tab_group(pane)
+
+    sessions.get.assert_called_once_with(
+        session_name="tabs_dev_1_3", default=None
+    )
+    server.new_session.assert_not_called()
+    assert result is existing_session


### PR DESCRIPTION
## Summary
- add helper that formats the hidden tab-group name via tmux formatting and ensures the session exists
- cover the helper with unit tests for creating and reusing the detached session

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c84f7ad9e083239666b8c01579cb58