### PR TITLE
Implement next tab cycling command

### DIFF
--- a/src/tmux_quick_tabs/next_tab.py
+++ b/src/tmux_quick_tabs/next_tab.py
@@ -1,0 +1,84 @@
+"""Implementation of the cycle-to-next-tab command."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .tab_groups import format_tab_group_name
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from libtmux import Pane, Session
+    from libtmux.server import Server
+
+__all__ = ["CycleNextTabCommand", "cycle_next_tab"]
+
+
+@dataclass(slots=True)
+class CycleNextTabCommand:
+    """Swap the active pane into the next hidden tab and rotate the buffer."""
+
+    pane: "Pane"
+
+    def run(self) -> None:
+        """Execute the command."""
+
+        tab_group = format_tab_group_name(self.pane)
+        pane_id = self._get_active_pane_id()
+        server: "Server" = self.pane.session.server
+
+        session = server.sessions.get(session_name=tab_group, default=None)
+        if session is None:
+            # Mirrors the original bug where ``tmux new`` is used instead of
+            # ``new-session``.  The call may fail to create the session which is
+            # why we attempt to fetch it again afterwards instead of assuming
+            # success.
+            server.cmd("new", "-d", "-s", tab_group)
+            session = server.sessions.get(session_name=tab_group, default=None)
+
+        # The swap-pane call is always attempted, even if the hidden session
+        # does not exist, matching the behaviour of the original shell script.
+        server.cmd("swap-pane", "-s", pane_id, "-t", f"{tab_group}:1")
+
+        if session is None:
+            return
+
+        self._rotate_hidden_windows(server=server, tab_group=tab_group, session=session)
+
+    def _get_active_pane_id(self) -> str:
+        pane_id = self.pane.get("pane_id")
+        if not pane_id:
+            pane_id = getattr(self.pane, "pane_id", None)
+        if not pane_id:
+            raise RuntimeError("Unable to determine active pane id")
+        return pane_id
+
+    def _rotate_hidden_windows(
+        self,
+        *,
+        server: "Server",
+        tab_group: str,
+        session: "Session",
+    ) -> None:
+        windows = list(getattr(session, "windows", []))
+        if len(windows) <= 1:
+            return
+
+        # Window indexes in the hidden session start at 1.  Rotation mirrors the
+        # shell implementation by swapping ``tab_group:i`` with ``tab_group:i+1``
+        # for the range ``[1, buffer_len)``.
+        for index in range(1, len(windows)):
+            server.cmd(
+                "swap-pane",
+                "-s",
+                f"{tab_group}:{index}",
+                "-t",
+                f"{tab_group}:{index + 1}",
+            )
+
+
+def cycle_next_tab(pane: "Pane") -> None:
+    """Convenience wrapper that executes :class:`CycleNextTabCommand`."""
+
+    CycleNextTabCommand(pane=pane).run()
+

--- a/tests/test_next_tab.py
+++ b/tests/test_next_tab.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import Mock, call
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from tmux_quick_tabs.next_tab import CycleNextTabCommand  # noqa: E402  - added to sys.path at runtime
+
+
+def make_pane(*, tab_group: str = "tabs_default", pane_id: str = "%1"):
+    pane = Mock()
+    pane.display_message.return_value = tab_group
+    pane.get.return_value = pane_id
+    pane.session = Mock()
+    server = Mock()
+    pane.session.server = server
+    sessions = Mock()
+    server.sessions = sessions
+    return pane, server, sessions
+
+
+def test_cycle_next_tab_rotates_when_session_exists():
+    pane, server, sessions = make_pane(tab_group="tabs_dev_main_1", pane_id="%5")
+    session = Mock()
+    session.windows = [Mock(), Mock(), Mock()]
+    sessions.get.return_value = session
+
+    command = CycleNextTabCommand(pane=pane)
+    command.run()
+
+    sessions.get.assert_called_once_with(session_name="tabs_dev_main_1", default=None)
+    assert server.cmd.call_args_list == [
+        call("swap-pane", "-s", "%5", "-t", "tabs_dev_main_1:1"),
+        call("swap-pane", "-s", "tabs_dev_main_1:1", "-t", "tabs_dev_main_1:2"),
+        call("swap-pane", "-s", "tabs_dev_main_1:2", "-t", "tabs_dev_main_1:3"),
+    ]
+
+
+def test_cycle_next_tab_creates_missing_session_with_buggy_command():
+    pane, server, sessions = make_pane(tab_group="tabs_work_1_0", pane_id="%3")
+    session = Mock()
+    session.windows = [Mock()]
+    sessions.get.side_effect = [None, session]
+
+    command = CycleNextTabCommand(pane=pane)
+    command.run()
+
+    assert sessions.get.call_args_list == [
+        call(session_name="tabs_work_1_0", default=None),
+        call(session_name="tabs_work_1_0", default=None),
+    ]
+    assert server.cmd.call_args_list == [
+        call("new", "-d", "-s", "tabs_work_1_0"),
+        call("swap-pane", "-s", "%3", "-t", "tabs_work_1_0:1"),
+    ]
+


### PR DESCRIPTION
## Summary
- add the CycleNextTabCommand that cycles panes through the hidden tab session while mirroring the tmux new bug
- attempt the swap-pane call unconditionally and rotate hidden windows when available
- cover scenarios with and without a pre-existing tab session in dedicated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c851ef73508323972222609c61a0e6