### PR TITLE
Implement choose-tab tree command

### DIFF
--- a/src/tmux_quick_tabs/choose_tab.py
+++ b/src/tmux_quick_tabs/choose_tab.py
@@ -1,0 +1,91 @@
+"""Implementation of the choose-tab tree command."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from libtmux import Server
+
+from .tab_groups import format_tab_group_name, get_or_create_tab_group
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from libtmux import Pane
+
+__all__ = [
+    "CHOOSE_TREE_COMMAND",
+    "CHOOSE_TREE_FORMAT",
+    "ChooseTabCommand",
+    "run_choose_tab",
+]
+
+CHOOSE_TREE_FORMAT = "#{pane_title} #{pane_current_command} #{pane_current_path}"
+CHOOSE_TREE_COMMAND = "swap-pane -t '%%'"
+
+
+def _build_session_filter(session_name: str) -> str:
+    """Return the choose-tree filter targeting *session_name*."""
+
+    return f"#{{==:#{{session_name}},{session_name}}}"
+
+
+@dataclass(slots=True)
+class ChooseTabCommand:
+    """Invoke choose-tree restricted to panes inside the hidden tab session."""
+
+    pane: "Pane"
+
+    def run(self) -> None:
+        """Execute the command."""
+
+        tab_group = get_or_create_tab_group(self.pane)
+        session_name = None
+        if hasattr(tab_group, "get"):
+            session_name = tab_group.get("session_name")
+        if not session_name:
+            session_name = format_tab_group_name(self.pane)
+        self.pane.cmd(
+            "choose-tree",
+            "-F",
+            CHOOSE_TREE_FORMAT,
+            "-f",
+            _build_session_filter(session_name),
+            CHOOSE_TREE_COMMAND,
+        )
+
+
+def _resolve_pane(server: Server, pane_id: str | None) -> "Pane":
+    """Return the tmux pane identified by *pane_id*."""
+
+    if pane_id is None:
+        try:
+            pane_id = os.environ["TMUX_PANE"]
+        except KeyError as exc:  # pragma: no cover - defensive programming
+            raise RuntimeError(
+                "TMUX_PANE environment variable is not set and no pane_id was provided"
+            ) from exc
+    pane = server.panes.get(pane_id=pane_id, default=None)
+    if pane is None:  # pragma: no cover - defensive programming
+        raise RuntimeError(f"Unable to locate pane {pane_id!r} on the tmux server")
+    return pane
+
+
+def run_choose_tab(
+    *,
+    server: Server | None = None,
+    pane: "Pane" | None = None,
+    pane_id: str | None = None,
+) -> None:
+    """Run the choose-tab command for *pane* or the active tmux pane."""
+
+    if pane is None:
+        server = Server() if server is None else server
+        pane = _resolve_pane(server, pane_id)
+    else:
+        if server is None:
+            server = getattr(pane.session, "server", None)
+        if server is None:  # pragma: no cover - defensive programming
+            raise RuntimeError("The provided pane is not associated with a tmux server")
+    command = ChooseTabCommand(pane=pane)
+    command.run()

--- a/tests/test_choose_tab.py
+++ b/tests/test_choose_tab.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from tmux_quick_tabs.choose_tab import (  # noqa: E402  - added to sys.path at runtime
+    CHOOSE_TREE_COMMAND,
+    CHOOSE_TREE_FORMAT,
+    run_choose_tab,
+)
+
+
+def make_server_and_pane():
+    server = Mock()
+    server.panes = Mock()
+    pane = Mock()
+    pane.session = Mock()
+    pane.session.server = server
+    server.panes.get.return_value = pane
+    return server, pane
+
+
+def test_run_choose_tab_invokes_choose_tree_with_expected_arguments():
+    server, pane = make_server_and_pane()
+    tab_session = Mock()
+    tab_session.get.return_value = "tabs_main_dev_1"
+
+    with patch("tmux_quick_tabs.choose_tab.get_or_create_tab_group", return_value=tab_session) as get_group:
+        run_choose_tab(server=server, pane_id="@7")
+
+    server.panes.get.assert_called_once_with(pane_id="@7", default=None)
+    get_group.assert_called_once_with(pane)
+    tab_session.get.assert_called_once_with("session_name")
+    pane.cmd.assert_called_once_with(
+        "choose-tree",
+        "-F",
+        CHOOSE_TREE_FORMAT,
+        "-f",
+        "#{==:#{session_name},tabs_main_dev_1}",
+        CHOOSE_TREE_COMMAND,
+    )
+
+
+class FakePane:
+    def __init__(self, server: Mock, selection: str):
+        self.session = Mock()
+        self.session.server = server
+        self._selection = selection
+        self.calls: list[tuple[object, ...]] = []
+
+    def cmd(self, *args):
+        self.calls.append(args)
+        assert args[0] == "choose-tree"
+        command_string = args[-1]
+        assert command_string == CHOOSE_TREE_COMMAND
+        self.session.server.cmd("swap-pane", "-t", self._selection)
+        return []
+
+
+def test_run_choose_tab_swaps_active_pane_with_chosen_target():
+    server = Mock()
+    server.panes = Mock()
+    selection = "tabs_session:1.0"
+    pane = FakePane(server=server, selection=selection)
+    server.panes.get.return_value = pane
+    tab_session = Mock()
+    tab_session.get.return_value = "tabs_session_1_0"
+
+    with patch("tmux_quick_tabs.choose_tab.get_or_create_tab_group", return_value=tab_session):
+        run_choose_tab(server=server, pane_id="@3")
+
+    server.cmd.assert_called_once_with("swap-pane", "-t", selection)
+    assert pane.calls == [
+        (
+            "choose-tree",
+            "-F",
+            CHOOSE_TREE_FORMAT,
+            "-f",
+            "#{==:#{session_name},tabs_session_1_0}",
+            CHOOSE_TREE_COMMAND,
+        )
+    ]


### PR DESCRIPTION
## Summary
- add a choose-tab command that filters panes within the hidden tab session and runs swap-pane via choose-tree
- ensure the command locates the active pane when not provided and falls back to tmux formatting if the session name is unavailable
- add unit tests that simulate choose-tree selection and verify swap-pane execution

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c852020de0832390c5c8a8ffdac719