### PR TITLE
Implement close tab command

### DIFF
--- a/src/tmux_quick_tabs/close_tab.py
+++ b/src/tmux_quick_tabs/close_tab.py
@@ -1,0 +1,61 @@
+"""Implementation of the close-tab command."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .tab_groups import format_tab_group_name
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from libtmux import Pane
+
+__all__ = ["ACTIVE_PANE_FORMAT", "CloseTabCommand", "close_tab"]
+
+# Matches ``tmux display -p "#{pane_id}"`` from the shell implementation.
+ACTIVE_PANE_FORMAT = "#{pane_id}"
+
+
+def _format_active_pane_id(pane: "Pane") -> str:
+    """Return the active pane id for *pane*."""
+
+    message = pane.display_message(ACTIVE_PANE_FORMAT, get_text=True)
+    if isinstance(message, list):
+        if not message:
+            raise RuntimeError("tmux did not return an active pane id")
+        return message[0]
+    if not isinstance(message, str):
+        raise RuntimeError("Unexpected response from tmux when formatting active pane id")
+    return message
+
+
+@dataclass(slots=True)
+class CloseTabCommand:
+    """Swap the active pane into the hidden session and kill it."""
+
+    pane: "Pane"
+
+    def run(self) -> None:
+        """Execute the close-tab command."""
+
+        tab_group_name = format_tab_group_name(self.pane)
+        active_pane_id = _format_active_pane_id(self.pane)
+        server = self.pane.session.server
+
+        hidden_session = server.sessions.get(session_name=tab_group_name, default=None)
+        if hidden_session is None:
+            server.cmd("kill-pane", "-t", active_pane_id)
+            return
+
+        # Mirrors ``tmux swap-pane -t $tab_group:1`` which implicitly swaps the
+        # active pane with the hidden pane. No rotation occurs for this command.
+        server.cmd("swap-pane", "-t", f"{tab_group_name}:1")
+        server.cmd("kill-pane", "-t", f"{tab_group_name}:1")
+        # Intentionally leave the hidden session running even if no panes remain,
+        # matching the original shell implementation's leak.
+
+
+def close_tab(pane: "Pane") -> None:
+    """Convenience wrapper around :class:`CloseTabCommand`."""
+
+    CloseTabCommand(pane=pane).run()

--- a/tests/test_close_tab.py
+++ b/tests/test_close_tab.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import Mock, call
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from tmux_quick_tabs.close_tab import (  # noqa: E402  - added to sys.path at runtime
+    ACTIVE_PANE_FORMAT,
+    close_tab,
+)
+from tmux_quick_tabs.tab_groups import TAB_GROUP_FORMAT  # noqa: E402  - added to sys.path at runtime
+
+
+def make_pane(*, tab_group: str = "tabs_main_dev_1", pane_id: str = "%0"):
+    pane = Mock()
+    server = Mock()
+    sessions = Mock()
+    server.sessions = sessions
+    pane.session = Mock()
+    pane.session.server = server
+
+    def display_message(format_string: str, get_text: bool = True):
+        if format_string == TAB_GROUP_FORMAT:
+            return tab_group
+        if format_string == ACTIVE_PANE_FORMAT:
+            return pane_id
+        raise AssertionError(f"Unexpected format string: {format_string}")
+
+    pane.display_message.side_effect = display_message
+    return pane, server, sessions
+
+
+def test_close_tab_kills_active_pane_when_hidden_session_missing():
+    pane, server, sessions = make_pane(tab_group="tabs_alpha", pane_id="%5")
+    sessions.get.return_value = None
+
+    close_tab(pane)
+
+    pane.display_message.assert_any_call(TAB_GROUP_FORMAT, get_text=True)
+    pane.display_message.assert_any_call(ACTIVE_PANE_FORMAT, get_text=True)
+    sessions.get.assert_called_once_with(session_name="tabs_alpha", default=None)
+    server.cmd.assert_called_once_with("kill-pane", "-t", "%5")
+
+
+def test_close_tab_swaps_and_kills_hidden_pane():
+    pane, server, sessions = make_pane(tab_group="tabs_work_main", pane_id="%3")
+    hidden_session = Mock()
+    sessions.get.return_value = hidden_session
+
+    close_tab(pane)
+
+    assert server.cmd.call_args_list == [
+        call("swap-pane", "-t", "tabs_work_main:1"),
+        call("kill-pane", "-t", "tabs_work_main:1"),
+    ]
+
+
+def test_close_tab_keeps_hidden_session_alive_when_empty():
+    pane, server, sessions = make_pane(tab_group="tabs_empty", pane_id="%7")
+    hidden_session = Mock()
+    hidden_session.windows = []
+    sessions.get.return_value = hidden_session
+
+    close_tab(pane)
+
+    hidden_session.kill_session.assert_not_called()
+    for recorded_call in server.cmd.call_args_list:
+        assert recorded_call.args[0] != "kill-session"
+
+
+def test_close_tab_supports_list_output_for_active_pane_id():
+    pane, server, sessions = make_pane(tab_group="tabs_list")
+
+    def display_message(format_string: str, get_text: bool = True):
+        if format_string == TAB_GROUP_FORMAT:
+            return "tabs_list"
+        if format_string == ACTIVE_PANE_FORMAT:
+            return ["%9"]
+        raise AssertionError(f"Unexpected format string: {format_string}")
+
+    pane.display_message.side_effect = display_message
+    sessions.get.return_value = None
+
+    close_tab(pane)
+
+    server.cmd.assert_called_once_with("kill-pane", "-t", "%9")


### PR DESCRIPTION
## Summary
- add a libtmux-driven close tab command that swaps the active pane with the hidden buffer and kills it
- preserve the hidden tab session leak while mirroring the original shell semantics
- cover the close command with unit tests for pane killing and session persistence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c85209b0388323ac1cda3271365586