### PR TITLE
Implement new tab command

### DIFF
--- a/src/tmux_quick_tabs/new_tab.py
+++ b/src/tmux_quick_tabs/new_tab.py
@@ -1,0 +1,122 @@
+"""Implementation of the create-new-tab command."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+import shutil
+from typing import TYPE_CHECKING
+
+from libtmux import Server
+
+from .new_window import INITIALIZATION_COMMAND
+from .tab_groups import get_or_create_tab_group
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from libtmux.pane import Pane
+    from libtmux.session import Session
+
+__all__ = [
+    "REQUIRED_EXECUTABLES",
+    "POPUP_COMMAND",
+    "NewTabCommand",
+    "run_new_tab",
+]
+
+REQUIRED_EXECUTABLES = ("zoxide", "fzf")
+POPUP_COMMAND = f'tmux send-keys "{INITIALIZATION_COMMAND}" Enter'
+
+
+@dataclass(slots=True)
+class NewTabCommand:
+    """Replicate the behaviour of ``scripts/new-tab.sh`` using libtmux."""
+
+    pane: "Pane"
+    server: Server | None = None
+
+    def __post_init__(self) -> None:
+        if self.server is None:
+            self.server = self.pane.session.server  # type: ignore[assignment]
+
+    def run(self) -> None:
+        """Execute the command."""
+
+        self._ensure_dependencies_available()
+        tab_group = get_or_create_tab_group(self.pane)
+        active_pane_id = self._active_pane_id()
+
+        new_window = tab_group.new_window(attach=False)
+        new_pane = new_window.attached_pane
+        if new_pane is None:
+            raise RuntimeError("tmux did not return a pane for the new hidden window")
+        new_pane_id = new_pane.get("pane_id")
+        if not new_pane_id:
+            raise RuntimeError("tmux did not provide a pane id for the new hidden window")
+
+        assert self.server is not None  # for type checkers
+        self.server.cmd("swap-pane", "-s", active_pane_id, "-t", new_pane_id)
+        self.server.cmd("display-popup", "-E", POPUP_COMMAND)
+        self._rotate_hidden_windows(tab_group)
+
+    def _ensure_dependencies_available(self) -> None:
+        missing = [name for name in REQUIRED_EXECUTABLES if shutil.which(name) is None]
+        if missing:
+            deps = ", ".join(sorted(missing))
+            raise RuntimeError(f"Missing required dependencies: {deps}")
+
+    def _active_pane_id(self) -> str:
+        pane_id = self.pane.get("pane_id")
+        if not pane_id:
+            raise RuntimeError("Unable to determine the active pane id")
+        return pane_id
+
+    def _rotate_hidden_windows(self, tab_group: "Session") -> None:
+        windows = list(tab_group.windows)
+        if len(windows) <= 1:
+            return
+        session_name = tab_group.get("session_name")
+        if not session_name:
+            raise RuntimeError("tmux did not provide the tab-group session name")
+        for index in range(1, len(windows)):
+            source = f"{session_name}:{index}"
+            target = f"{session_name}:{index + 1}"
+            assert self.server is not None
+            self.server.cmd("swap-pane", "-s", source, "-t", target)
+
+
+def _resolve_pane_id(pane_id: str | None) -> str:
+    if pane_id:
+        return pane_id
+    env_pane = os.environ.get("TMUX_PANE")
+    if env_pane:
+        return env_pane
+    raise RuntimeError(
+        "tmux-quick-tabs cannot determine the active pane; provide pane_id or set TMUX_PANE."
+    )
+
+
+def _lookup_pane(server: Server, pane_id: str) -> "Pane":
+    pane = server.panes.get(pane_id=pane_id, default=None)
+    if pane is None:
+        raise RuntimeError(f"tmux pane {pane_id!r} not found")
+    return pane
+
+
+def run_new_tab(
+    *,
+    server: Server | None = None,
+    pane: "Pane" | None = None,
+    pane_id: str | None = None,
+) -> None:
+    """Create a new tab for the active tmux pane."""
+
+    if pane is None:
+        server = Server() if server is None else server
+        pane_id = _resolve_pane_id(pane_id)
+        pane = _lookup_pane(server, pane_id)
+    else:
+        if server is None:
+            server = pane.session.server  # type: ignore[assignment]
+
+    command = NewTabCommand(pane=pane, server=server)
+    command.run()

--- a/tests/test_new_tab.py
+++ b/tests/test_new_tab.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock, call, patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+try:  # pragma: no cover - fallback for environments without libtmux
+    from libtmux import Server  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - executed only in CI where libtmux missing
+    libtmux_module = types.ModuleType("libtmux")
+
+    class Server:  # type: ignore[too-many-ancestors]
+        """Minimal stub used when libtmux is unavailable during tests."""
+
+        panes: Mock
+
+        def __init__(self) -> None:  # pragma: no cover - not used
+            self.panes = Mock()
+
+        def cmd(self, *args: object, **kwargs: object) -> None:  # pragma: no cover - not used
+            raise NotImplementedError
+
+    sys.modules["libtmux"] = libtmux_module
+    libtmux_module.Server = Server
+
+from tmux_quick_tabs.new_tab import (  # noqa: E402  - added to sys.path at runtime
+    POPUP_COMMAND,
+    run_new_tab,
+)
+
+
+def make_pane(server: Mock, pane_id: str = "%1") -> Mock:
+    pane = Mock()
+    pane.get.side_effect = lambda key: {"pane_id": pane_id}[key]
+    pane.session = Mock()
+    pane.session.server = server
+    return pane
+
+
+def test_run_new_tab_swaps_panes_opens_popup_and_rotates(monkeypatch: pytest.MonkeyPatch):
+    server = Mock(spec=["cmd", "panes"])
+    pane = make_pane(server, "%3")
+
+    tab_group = Mock()
+    new_window = Mock()
+    new_pane = Mock()
+    new_pane.get.return_value = "%7"
+    new_window.attached_pane = new_pane
+    tab_group.new_window.return_value = new_window
+    tab_group.windows = [Mock(), Mock(), Mock()]
+    tab_group.get.return_value = "tabs_dev_1_1"
+
+    monkeypatch.setattr(
+        "tmux_quick_tabs.new_tab.get_or_create_tab_group", lambda p: tab_group
+    )
+    monkeypatch.setattr("tmux_quick_tabs.new_tab.shutil.which", lambda name: f"/usr/bin/{name}")
+
+    run_new_tab(server=server, pane=pane)
+
+    tab_group.new_window.assert_called_once_with(attach=False)
+    assert server.cmd.call_args_list == [
+        call("swap-pane", "-s", "%3", "-t", "%7"),
+        call("display-popup", "-E", POPUP_COMMAND),
+        call("swap-pane", "-s", "tabs_dev_1_1:1", "-t", "tabs_dev_1_1:2"),
+        call("swap-pane", "-s", "tabs_dev_1_1:2", "-t", "tabs_dev_1_1:3"),
+    ]
+
+
+def test_run_new_tab_skips_rotation_with_single_hidden_window(monkeypatch: pytest.MonkeyPatch):
+    server = Mock(spec=["cmd", "panes"])
+    pane = make_pane(server)
+
+    tab_group = Mock()
+    new_window = Mock()
+    new_pane = Mock()
+    new_pane.get.return_value = "%8"
+    new_window.attached_pane = new_pane
+    tab_group.new_window.return_value = new_window
+    tab_group.windows = [Mock()]
+    tab_group.get.return_value = "tabs_example"
+
+    monkeypatch.setattr(
+        "tmux_quick_tabs.new_tab.get_or_create_tab_group", lambda p: tab_group
+    )
+    monkeypatch.setattr("tmux_quick_tabs.new_tab.shutil.which", lambda name: f"/usr/bin/{name}")
+
+    run_new_tab(server=server, pane=pane)
+
+    assert server.cmd.call_args_list == [
+        call("swap-pane", "-s", "%1", "-t", "%8"),
+        call("display-popup", "-E", POPUP_COMMAND),
+    ]
+
+
+def test_run_new_tab_fails_when_dependencies_missing(monkeypatch: pytest.MonkeyPatch):
+    server = Mock(spec=["cmd", "panes"])
+    pane = make_pane(server)
+
+    monkeypatch.setattr(
+        "tmux_quick_tabs.new_tab.shutil.which",
+        lambda name: None if name == "zoxide" else f"/usr/bin/{name}",
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        run_new_tab(server=server, pane=pane)
+
+    server.cmd.assert_not_called()
+    message = str(excinfo.value)
+    assert "Missing required dependencies" in message
+    assert "zoxide" in message
+    assert "fzf" not in message
+
+
+def test_run_new_tab_resolves_active_pane_from_server(monkeypatch: pytest.MonkeyPatch):
+    server = Mock()
+    server.cmd = Mock()
+    server.panes = Mock()
+    server.panes.get.return_value = pane = make_pane(server, "%9")
+
+    tab_group = Mock()
+    new_window = Mock()
+    new_pane = Mock()
+    new_pane.get.return_value = "%10"
+    new_window.attached_pane = new_pane
+    tab_group.new_window.return_value = new_window
+    tab_group.windows = [Mock(), Mock()]
+    tab_group.get.return_value = "tabs_work"
+
+    monkeypatch.setattr(
+        "tmux_quick_tabs.new_tab.get_or_create_tab_group", lambda p: tab_group
+    )
+    monkeypatch.setattr("tmux_quick_tabs.new_tab.shutil.which", lambda name: f"/usr/bin/{name}")
+
+    with patch.dict(os.environ, {"TMUX_PANE": "%9"}, clear=False):
+        run_new_tab(server=server)
+
+    server.panes.get.assert_called_once_with(pane_id="%9", default=None)
+    assert server.cmd.call_args_list[0] == call("swap-pane", "-s", "%9", "-t", "%10")


### PR DESCRIPTION
## Summary
- add a libtmux-based new tab command that mirrors the shell scripts
- swap the active pane into the hidden session, trigger the popup initialiser, and rotate hidden windows
- cover the command with unit tests that verify popup invocation, rotation, dependency failures, and pane lookup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8546d7f4c8323afaa80d477cfd29b