### PR TITLE
Log follow-up issue for close tab source pane

### DIFF
--- a/.github/issues/provide-source-pane-when-swapping.md
+++ b/.github/issues/provide-source-pane-when-swapping.md
@@ -1,0 +1,11 @@
+# Provide source pane when swapping in close tab command
+
+## Summary
+The new `close_tab` command swaps the hidden buffer pane into the active tab without specifying a source pane. libtmux does not implicitly select the current pane when commands are executed outside of a tmux client, so `swap-pane -t tab_group_name:1` may target the wrong pane or fail entirely. We need to pass the active pane id (`-s`) when invoking `swap-pane` to ensure the intended pane is swapped.
+
+## Follow-up Tasks
+- Update `close_tab.py` to supply the source pane id when calling `swap-pane`.
+- Add regression coverage that exercises the command through libtmux to ensure the explicit source pane is required.
+
+## References
+- Review suggestion in PR implementing the close tab command (path `src/tmux_quick_tabs/close_tab.py`, line 53).


### PR DESCRIPTION
## Summary
- record a follow-up issue requesting the close tab command supply a source pane when swapping

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68c85b45a2a48323b6d72449ce646f4d