### PR TITLE
Implement new tab command

### DIFF
--- a/src/tmux_quick_tabs/new_tab.py
+++ b/src/tmux_quick_tabs/new_tab.py
@@ -24,7 +24,8 @@ __all__ = [
 ]
 
 REQUIRED_EXECUTABLES = ("zoxide", "fzf")
-POPUP_COMMAND = f'tmux send-keys "{INITIALIZATION_COMMAND}" Enter'
+_ESCAPED_INITIALIZATION_COMMAND = INITIALIZATION_COMMAND.replace("$", r"\$")
+POPUP_COMMAND = f'tmux send-keys "{_ESCAPED_INITIALIZATION_COMMAND}" Enter'
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
- add a libtmux-based new tab command that mirrors the shell scripts
- swap the active pane into the hidden session, trigger the popup initialiser, and rotate hidden windows
- ensure the popup command escapes shell expansion so the directory picker runs in the new tab
- cover the command with unit tests that verify popup invocation, rotation, dependency failures, and pane lookup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c85c91d890832389fd41d6bfa7b655