### PR TITLE
Add centralized dependency warnings

### DIFF
--- a/src/tmux_quick_tabs/choose_tab.py
+++ b/src/tmux_quick_tabs/choose_tab.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from libtmux import Server
 
+from .dependencies import REQUIRED_EXECUTABLES, warn_missing_dependencies
 from .tab_groups import format_tab_group_name, get_or_create_tab_group
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
@@ -39,6 +40,7 @@ class ChooseTabCommand:
     def run(self) -> None:
         """Execute the command."""
 
+        warn_missing_dependencies(REQUIRED_EXECUTABLES)
         tab_group = get_or_create_tab_group(self.pane)
         session_name = None
         if hasattr(tab_group, "get"):

--- a/src/tmux_quick_tabs/close_tab.py
+++ b/src/tmux_quick_tabs/close_tab.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from .dependencies import REQUIRED_EXECUTABLES, warn_missing_dependencies
 from .tab_groups import format_tab_group_name
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
@@ -38,6 +39,7 @@ class CloseTabCommand:
     def run(self) -> None:
         """Execute the close-tab command."""
 
+        warn_missing_dependencies(REQUIRED_EXECUTABLES)
         tab_group_name = format_tab_group_name(self.pane)
         active_pane_id = _format_active_pane_id(self.pane)
         server = self.pane.session.server

--- a/src/tmux_quick_tabs/dependencies.py
+++ b/src/tmux_quick_tabs/dependencies.py
@@ -1,0 +1,47 @@
+"""Utilities for validating external command dependencies."""
+
+from __future__ import annotations
+
+import shutil
+import warnings
+from typing import Iterable, Tuple
+
+__all__ = [
+    "DependencyWarning",
+    "REQUIRED_EXECUTABLES",
+    "find_missing_dependencies",
+    "warn_missing_dependencies",
+]
+
+
+class DependencyWarning(UserWarning):
+    """Warning raised when optional tmux-quick-tabs dependencies are missing."""
+
+
+REQUIRED_EXECUTABLES: Tuple[str, ...] = ("zoxide", "fzf")
+
+
+def find_missing_dependencies(
+    names: Iterable[str] = REQUIRED_EXECUTABLES,
+) -> tuple[str, ...]:
+    """Return a tuple of dependency names that are not available on ``PATH``."""
+
+    missing = tuple(sorted(name for name in names if shutil.which(name) is None))
+    return missing
+
+
+def warn_missing_dependencies(
+    names: Iterable[str] = REQUIRED_EXECUTABLES,
+) -> tuple[str, ...]:
+    """Warn about missing dependencies while allowing execution to continue."""
+
+    missing = find_missing_dependencies(names)
+    if missing:
+        dependency_list = ", ".join(missing)
+        warnings.warn(
+            f"Missing optional dependencies for tmux-quick-tabs: {dependency_list}.",
+            DependencyWarning,
+            stacklevel=2,
+        )
+    return missing
+

--- a/src/tmux_quick_tabs/new_window.py
+++ b/src/tmux_quick_tabs/new_window.py
@@ -9,6 +9,8 @@ from typing import TextIO
 from libtmux import Server
 from libtmux.exc import LibTmuxException
 
+from .dependencies import REQUIRED_EXECUTABLES, warn_missing_dependencies
+
 __all__ = [
     "INITIALIZATION_COMMAND",
     "NewWindowCommand",
@@ -46,6 +48,7 @@ class NewWindowCommand:
 
         name = self.prompt()
         args = self._split_name(name)
+        warn_missing_dependencies(REQUIRED_EXECUTABLES)
         try:
             self.server.cmd("neww", "-n", *args)
         except LibTmuxException:

--- a/src/tmux_quick_tabs/next_tab.py
+++ b/src/tmux_quick_tabs/next_tab.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from .dependencies import REQUIRED_EXECUTABLES, warn_missing_dependencies
 from .tab_groups import format_tab_group_name
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
@@ -23,6 +24,7 @@ class CycleNextTabCommand:
     def run(self) -> None:
         """Execute the command."""
 
+        warn_missing_dependencies(REQUIRED_EXECUTABLES)
         tab_group = format_tab_group_name(self.pane)
         pane_id = self._get_active_pane_id()
         server: "Server" = self.pane.session.server

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Shared pytest fixtures for tmux-quick-tabs tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_dependency_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend required executables are present unless a test overrides it."""
+
+    monkeypatch.setattr(
+        "tmux_quick_tabs.dependencies.shutil.which",
+        lambda name: f"/usr/bin/{name}",
+    )

--- a/tests/test_new_tab.py
+++ b/tests/test_new_tab.py
@@ -15,6 +15,7 @@ if str(SRC_PATH) not in sys.path:
 
 try:  # pragma: no cover - fallback for environments without libtmux
     from libtmux import Server  # type: ignore
+    from libtmux.exc import LibTmuxException  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - executed only in CI where libtmux missing
     libtmux_module = types.ModuleType("libtmux")
 
@@ -29,9 +30,22 @@ except ModuleNotFoundError:  # pragma: no cover - executed only in CI where libt
         def cmd(self, *args: object, **kwargs: object) -> None:  # pragma: no cover - not used
             raise NotImplementedError
 
-    sys.modules["libtmux"] = libtmux_module
-    libtmux_module.Server = Server
+    exc_module = types.ModuleType("libtmux.exc")
 
+    class LibTmuxException(Exception):
+        """Placeholder exception matching the real libtmux hierarchy."""
+
+    exc_module.LibTmuxException = LibTmuxException
+
+    libtmux_module.Server = Server
+    libtmux_module.exc = exc_module
+    libtmux_module.__path__ = []  # type: ignore[attr-defined]
+    sys.modules["libtmux"] = libtmux_module
+    sys.modules["libtmux.exc"] = exc_module
+
+    from libtmux.exc import LibTmuxException  # type: ignore  # noqa: E402
+
+from tmux_quick_tabs.dependencies import DependencyWarning  # noqa: E402  - added to sys.path at runtime
 from tmux_quick_tabs.new_tab import (  # noqa: E402  - added to sys.path at runtime
     POPUP_COMMAND,
     run_new_tab,
@@ -62,8 +76,6 @@ def test_run_new_tab_swaps_panes_opens_popup_and_rotates(monkeypatch: pytest.Mon
     monkeypatch.setattr(
         "tmux_quick_tabs.new_tab.get_or_create_tab_group", lambda p: tab_group
     )
-    monkeypatch.setattr("tmux_quick_tabs.new_tab.shutil.which", lambda name: f"/usr/bin/{name}")
-
     run_new_tab(server=server, pane=pane)
 
     tab_group.new_window.assert_called_once_with(attach=False)
@@ -91,8 +103,6 @@ def test_run_new_tab_skips_rotation_with_single_hidden_window(monkeypatch: pytes
     monkeypatch.setattr(
         "tmux_quick_tabs.new_tab.get_or_create_tab_group", lambda p: tab_group
     )
-    monkeypatch.setattr("tmux_quick_tabs.new_tab.shutil.which", lambda name: f"/usr/bin/{name}")
-
     run_new_tab(server=server, pane=pane)
 
     assert server.cmd.call_args_list == [
@@ -101,23 +111,33 @@ def test_run_new_tab_skips_rotation_with_single_hidden_window(monkeypatch: pytes
     ]
 
 
-def test_run_new_tab_fails_when_dependencies_missing(monkeypatch: pytest.MonkeyPatch):
+def test_run_new_tab_warns_when_dependencies_missing(monkeypatch: pytest.MonkeyPatch):
     server = Mock(spec=["cmd", "panes"])
     pane = make_pane(server)
 
+    tab_group = Mock()
+    new_window = Mock()
+    new_pane = Mock()
+    new_pane.get.return_value = "%4"
+    new_window.attached_pane = new_pane
+    tab_group.new_window.return_value = new_window
+    tab_group.windows = [Mock(), Mock()]
+    tab_group.get.return_value = "tabs_warn"
+
     monkeypatch.setattr(
-        "tmux_quick_tabs.new_tab.shutil.which",
+        "tmux_quick_tabs.new_tab.get_or_create_tab_group",
+        lambda p: tab_group,
+    )
+    monkeypatch.setattr(
+        "tmux_quick_tabs.dependencies.shutil.which",
         lambda name: None if name == "zoxide" else f"/usr/bin/{name}",
     )
 
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.warns(DependencyWarning) as record:
         run_new_tab(server=server, pane=pane)
 
-    server.cmd.assert_not_called()
-    message = str(excinfo.value)
-    assert "Missing required dependencies" in message
-    assert "zoxide" in message
-    assert "fzf" not in message
+    assert server.cmd.call_args_list[0] == call("swap-pane", "-s", "%1", "-t", "%4")
+    assert any("zoxide" in str(w.message) for w in record)
 
 
 def test_run_new_tab_resolves_active_pane_from_server(monkeypatch: pytest.MonkeyPatch):
@@ -138,8 +158,6 @@ def test_run_new_tab_resolves_active_pane_from_server(monkeypatch: pytest.Monkey
     monkeypatch.setattr(
         "tmux_quick_tabs.new_tab.get_or_create_tab_group", lambda p: tab_group
     )
-    monkeypatch.setattr("tmux_quick_tabs.new_tab.shutil.which", lambda name: f"/usr/bin/{name}")
-
     with patch.dict(os.environ, {"TMUX_PANE": "%9"}, clear=False):
         run_new_tab(server=server)
 


### PR DESCRIPTION
## Summary
- add a dependency utility that warns when zoxide or fzf are missing instead of raising
- update every command to invoke the shared dependency check so behaviour stays consistent
- extend the test suite with fixtures and warning coverage for the dependency scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c85f48f0e883239c3566ec281cd6dd