### PR TITLE
Add Step 10 automated tests and linting configuration

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,11 @@
+# ShellCheck configuration for tmux-quick-tabs legacy scripts.
+# The scripts mirror historical tmux behaviour, including unquoted variables
+# and other patterns flagged as style issues. Disable those diagnostics so that
+# ShellCheck can focus on surfacing correctness problems without rewriting the
+# reference implementations.
+disable=SC2086
+disable=SC2116
+disable=SC2034
+disable=SC2181
+disable=SC2004
+disable=SC2162

--- a/README.md
+++ b/README.md
@@ -74,5 +74,22 @@ You can inspect the placeholder CLI with:
 python -m tmux_quick_tabs --version
 ```
 
+### Automated tests and linting
+
+Run the Python unit tests with [pytest](https://docs.pytest.org/):
+
+```bash
+pytest
+```
+
+The legacy shell scripts remain the reference implementation for tmux behaviour
+and are linted with [ShellCheck](https://www.shellcheck.net/) using a
+configuration that suppresses style-only warnings which would otherwise require
+rewriting them:
+
+```bash
+shellcheck scripts/*.sh
+```
+
 Future steps in the refactor will flesh out the Python package to replace the shell scripts
 shipped with this repository today.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ Repository = "https://github.com/meltingshoe/tmux-quick-tabs"
 dev = [
   "pre-commit>=3.5",
   "ruff>=0.4.7",
+  "pytest>=8.2",
 ]
 
 [project.scripts]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -ra
+pythonpath = src
+testpaths = tests

--- a/tests/test_choose_tab.py
+++ b/tests/test_choose_tab.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import types
 from pathlib import Path
@@ -123,3 +124,21 @@ def test_run_choose_tab_warns_about_missing_dependencies(monkeypatch: pytest.Mon
 
     pane.cmd.assert_called_once()
     assert record
+
+
+def test_run_choose_tab_resolves_pane_id_from_environment(monkeypatch: pytest.MonkeyPatch):
+    server, pane = make_server_and_pane()
+    pane.cmd.return_value = []
+    tab_session = Mock()
+    tab_session.get.return_value = "tabs_env"
+
+    monkeypatch.setattr(
+        "tmux_quick_tabs.choose_tab.get_or_create_tab_group",
+        lambda p: tab_session,
+    )
+    monkeypatch.setitem(os.environ, "TMUX_PANE", "@42")
+
+    run_choose_tab(server=server)
+
+    server.panes.get.assert_called_once_with(pane_id="@42", default=None)
+    pane.cmd.assert_called_once()


### PR DESCRIPTION
## Summary
- add a pytest configuration file and include pytest in the development extra
- extend command unit tests to cover environment-driven fallbacks
- configure shellcheck for the legacy scripts and document how to run the checks

## Testing
- pytest
- shellcheck scripts/*.sh

------
https://chatgpt.com/codex/tasks/task_e_68c86cd7c3548323b0ae6d2b4d76ae47